### PR TITLE
80% smaller SVG images.

### DIFF
--- a/tools/ui/icons/pepper.svg
+++ b/tools/ui/icons/pepper.svg
@@ -1,262 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 512 512"
-   height="512"
-   width="512"
-   version="1.1"
-   id="svg4206"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="pepper.svg"
-   inkscape:export-filename="/home/dani/git/crown/tools/level_editor/icons/pepper-16x16.png"
-   inkscape:export-xdpi="2.8099999"
-   inkscape:export-ydpi="2.8099999">
-  <sodipodi:namedview
-     pagecolor="#383a39"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     id="namedview4254"
-     showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="303.49014"
-     inkscape:cy="220.5889"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4206" />
-  <metadata
-     id="metadata4212">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs4210">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4548"
-       x="-0.1298326"
-       width="1.2596652"
-       y="-0.36840001"
-       height="1.7368">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="17.366543"
-         id="feGaussianBlur4550" />
-    </filter>
-  </defs>
-  <g
-     id="g4204"
-     transform="translate(-729.73419,-5.9420657)">
-    <rect
-       y="5.9420657"
-       x="729.73419"
-       height="512"
-       width="512"
-       id="rect4202"
-       style="opacity:1;fill:none;fill-opacity:0.23529412;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-    <g
-       transform="translate(735.93829,-2.1845494e-7)"
-       id="g4179">
-      <ellipse
-         transform="matrix(0.89363472,0,0,0.35091959,-19.84947,-967.8208)"
-         cx="308.94678"
-         cy="4014.7866"
-         rx="160.51324"
-         ry="56.568542"
-         id="path4155"
-         style="opacity:1;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1;filter:url(#filter4548)" />
-      <g
-         transform="matrix(0.78125,0,0,0.78125,42.364405,-2734.3548)"
-         id="g4198">
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           style="fill:#4e9a06;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 473.2387,3579.5713 c -12.35647,80.6229 -20.00128,133.4822 -25.25254,172.2362 l 59.5311,-115.9296 z"
-           id="path4216"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#a40000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 407.42433,3751.937 63.38385,6.6591 -110.45664,35.4263 z"
-           id="path4220"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#ef2929;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 477.68815,3765.1218 -108.10785,34.7052 144.58403,31.1253 z"
-           id="path4222"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#fce94f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 437.1251,3822.7358 78.35,17.1752 -64.63805,172.1428 z"
-           id="path4226"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#cc0000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 350.99529,3803.7782 -54.70739,69.968 124.27459,-54.8662 z"
-           id="path4228"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#ff6739;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 297.62715,3882.072 119.60222,-53.1844 -95.97736,244.9879 z"
-           id="path4230"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#fcaf3e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 331.25492,4069.9043 111.00001,-54.4289 -13.11298,-193.6839 z"
-           id="path4232"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#ef2929;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 166.2326,3928.4743 122.9963,-46.9024 23.5461,187.8298 z"
-           id="path4234"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           sodipodi:nodetypes="cccc"
-           style="fill:#880000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 98.705059,4026.7014 61.123141,-93.5123 144.54045,139.4946 z"
-           id="path4236"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           style="fill:#f57900;fill-opacity:0.94117647;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 7.5447786,3812.2394 85.3729854,208.5781 60.115246,-92.0074 z"
-           id="path4238"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           style="fill:#f07e36;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="M 120.81691,3675.9239 75.022388,3855.6623 12.8925,3805.9488 Z"
-           id="path4242"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           style="fill:#a40000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 232.05717,3761.3926 -103.85428,-82.6296 -15.83283,62.6565 z"
-           id="path4244"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           style="fill:#fcaf3e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 230.15833,3769.1781 -51.83953,104.9811 4.32472,-112.9211 z"
-           id="path4246"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           inkscape:connector-curvature="0"
-           style="fill:#83ed57;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 445.27233,3609.085 9.77257,39.1574 -89.75077,-78.1779 z"
-           id="path4258" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           inkscape:connector-curvature="0"
-           style="fill:#8ae234;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 346.33158,3564.1438 -38.04107,53.9382 147.17276,41.1691 z"
-           id="path4260" />
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           inkscape:connector-curvature="0"
-           style="fill:#089a06;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 304.6317,3624.6916 53.62926,48.6981 93.97939,-6.3756 z"
-           id="path4262" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           inkscape:connector-curvature="0"
-           style="fill:#32b307;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 245.23708,3570.5174 92.33484,-8.6419 -38.17709,53.996 z"
-           id="path4264" />
-        <path
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128c.png"
-           inkscape:connector-curvature="0"
-           style="fill:#73d216;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.31103683"
-           d="m 235.80913,3573.4406 -61.00215,32.7538 100.63644,0.1396 z"
-           id="path4266" />
-        <rect
-           inkscape:export-ydpi="22.5"
-           inkscape:export-xdpi="22.5"
-           inkscape:export-filename="/home/michela/Immagini/icona-128d.png"
-           style="opacity:1;fill:none;fill-opacity:0;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="rect33269"
-           width="512"
-           height="512"
-           x="5.5099416"
-           y="3561.8755" />
+<svg height="512" viewBox="0 0 512 512" width="512" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <filter id="a" color-interpolation-filters="sRGB" height="1.7368" width="1.259665" x="-.129833" y="-.3684">
+    <feGaussianBlur stdDeviation="17.366543"/>
+  </filter>
+  <g transform="translate(-729.73419 -5.942066)">
+    <path d="m729.73419 5.942066h512v512h-512z" fill="none"/>
+    <ellipse cx="308.94678" cy="4014.7866" fill-opacity=".235294" filter="url(#a)" rx="160.51324" ry="56.568542" transform="matrix(.89363472 0 0 .35091959 716.08882 -967.8208)"/>
+    <g transform="matrix(.78125 0 0 .78125 778.302695 -2734.3548)">
+      <g fill-rule="evenodd">
+        <path d="m473.2387 3579.5713c-12.35647 80.6229-20.00128 133.4822-25.25254 172.2362l59.5311-115.9296z" fill="#4e9a06"/>
+        <path d="m407.42433 3751.937 63.38385 6.6591-110.45664 35.4263z" fill="#a40000"/>
+        <path d="m477.68815 3765.1218-108.10785 34.7052 144.58403 31.1253z" fill="#ef2929"/>
+        <path d="m437.1251 3822.7358 78.35 17.1752-64.63805 172.1428z" fill="#fce94f"/>
+        <path d="m350.99529 3803.7782-54.70739 69.968 124.27459-54.8662z" fill="#c00"/>
+        <path d="m297.62715 3882.072 119.60222-53.1844-95.97736 244.9879z" fill="#ff6739"/>
+        <path d="m331.25492 4069.9043 111.00001-54.4289-13.11298-193.6839z" fill="#fcaf3e"/>
+        <path d="m166.2326 3928.4743 122.9963-46.9024 23.5461 187.8298z" fill="#ef2929"/>
+        <path d="m98.705059 4026.7014 61.123141-93.5123 144.54045 139.4946z" fill="#800"/>
+        <path d="m7.5447786 3812.2394 85.3729854 208.5781 60.115246-92.0074z" fill="#f57900" fill-opacity=".941176"/>
+        <path d="m120.81691 3675.9239-45.794522 179.7384-62.129888-49.7135z" fill="#f07e36"/>
+        <path d="m232.05717 3761.3926-103.85428-82.6296-15.83283 62.6565z" fill="#a40000"/>
+        <path d="m230.15833 3769.1781-51.83953 104.9811 4.32472-112.9211z" fill="#fcaf3e"/>
+        <path d="m445.27233 3609.085 9.77257 39.1574-89.75077-78.1779z" fill="#83ed57"/>
+        <path d="m346.33158 3564.1438-38.04107 53.9382 147.17276 41.1691z" fill="#8ae234"/>
+        <path d="m304.6317 3624.6916 53.62926 48.6981 93.97939-6.3756z" fill="#089a06"/>
+        <path d="m245.23708 3570.5174 92.33484-8.6419-38.17709 53.996z" fill="#32b307"/>
+        <path d="m235.80913 3573.4406-61.00215 32.7538 100.63644.1396z" fill="#73d216"/>
       </g>
+      <path d="m5.509942 3561.8755h512v512h-512z" fill="none"/>
     </g>
   </g>
 </svg>

--- a/tools/ui/icons/theme.svg
+++ b/tools/ui/icons/theme.svg
@@ -1,676 +1,124 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="16"
-   height="16"
-   viewBox="0 0 16 16"
-   id="svg4213"
-   version="1.1"
-   inkscape:version="0.91 r13725"
-   inkscape:export-filename="/home/dani/git/crown/tools/level_editor/icons/tool-place.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90"
-   sodipodi:docname="theme.svg">
-  <defs
-     id="defs4215">
-    <marker
-       inkscape:stockid="Arrow2Mend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow2Mend"
-       style="overflow:visible"
-       inkscape:isstock="true">
-      <path
-         inkscape:connector-curvature="0"
-         id="path13972"
-         style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:#bebebe;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)" />
-    </marker>
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#3a3b39"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="266.17688"
-     inkscape:cy="5.5119614"
-     inkscape:document-units="px"
-     inkscape:current-layer="g6039"
-     showgrid="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4761"
-       dotted="true"
-       visible="false" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata4218">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-1036.3622)">
-    <g
-       style="display:inline"
-       id="tool-place"
-       inkscape:label="#g5067"
-       inkscape:export-filename="/home/dani/Downloads/tool-place.png"
-       inkscape:export-xdpi="90"
-       inkscape:export-ydpi="90"
-       transform="matrix(0.32173538,0,0,0.32167334,-47.594055,938.50982)">
-      <g
-         id="g6039"
-         transform="matrix(1.4022891,0,0,1.4025484,-69.478744,-132.49628)">
-        <g
-           id="g10468"
-           inkscape:label="tool-place">
-          <rect
-             ry="0.428545"
-             y="313.57486"
-             x="157.25436"
-             height="31.030304"
-             width="31.030304"
-             id="rect3436"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.969697;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
-             ry="0"
-             y="335.73917"
-             x="166.12029"
-             height="11.082483"
-             width="11.082395"
-             id="rect4400"
-             style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.10701809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path18807"
-             d="m 171.66148,313.5742 0,15.51548"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:2.21648788;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path18809"
-             d="m 166.12028,324.65669 5.5412,6.64949 5.5412,-6.64949 z"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.21648788px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <rect
-             y="311.3577"
-             x="155.03789"
-             height="35.463947"
-             width="35.463665"
-             id="rect9820"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(0.99181083,0,0,1.0343661,277.99458,-54.840593)"
-           style="display:inline"
-           id="g9829"
-           inkscape:label="snap-to-grid">
-          <rect
-             style="display:inline;opacity:0.98000004;fill:none;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.26799989;stroke-opacity:1"
-             id="rect4346"
-             width="44.799999"
-             height="44.799999"
-             x="231.57103"
-             y="349.72113"
-             rx="0.17778684"
-             transform="matrix(0.69836874,0,0,0.66964224,73.228738,122.99087)" />
-          <rect
-             rx="0.071120985"
-             y="374.62115"
-             x="251.47112"
-             height="2.4999964"
-             width="20.000082"
-             id="rect4312"
-             style="display:inline;opacity:0.98000004;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.26799989;stroke-opacity:1"
-             transform="matrix(0.89390837,0,0,0.85714327,24.444204,52.213324)" />
-          <rect
-             style="display:inline;opacity:0.98000004;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.26799989;stroke-opacity:1"
-             id="rect4316"
-             width="20.000082"
-             height="2.4999964"
-             x="251.47112"
-             y="382.12115"
-             rx="0.071120985"
-             transform="matrix(0.89390837,0,0,0.85714327,24.444204,52.213324)" />
-          <rect
-             transform="matrix(0,0.85714327,-0.89390837,0,24.444204,52.213324)"
-             rx="0.071120583"
-             y="-258.97116"
-             x="369.62115"
-             height="2.5000103"
-             width="19.999971"
-             id="rect4318"
-             style="display:inline;opacity:0.98000004;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.26799989;stroke-opacity:1" />
-          <rect
-             style="display:inline;opacity:0.98000004;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.26799989;stroke-opacity:1"
-             id="rect4320"
-             width="19.999971"
-             height="2.5000103"
-             x="369.62115"
-             y="-266.47119"
-             rx="0.071120583"
-             transform="matrix(0,0.85714327,-0.89390837,0,24.444204,52.213324)" />
-          <g
-             transform="matrix(0.68748697,0.65920807,-0.73744045,0.70710678,343.58841,-54.025311)"
-             id="g18196">
-            <path
-               sodipodi:nodetypes="sssccsssccs"
-               inkscape:connector-curvature="0"
-               style="opacity:1;fill:#d40000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               d="m 240.50438,355.61768 c -4.14215,0 -7.50003,3.35786 -7.50003,7.49999 0,4.14213 3.35788,7.49999 7.50003,7.49999 l 4.57215,0 0,-4.5 -4.57215,0 c -1.65686,0 -3.00001,-1.34314 -3.00001,-2.99999 0,-1.65685 1.34315,-3 3.00001,-3 l 4.57215,0 0,-4.49999 z"
-               id="path17555" />
-            <g
-               id="g17557"
-               transform="matrix(1.2,0,0,1.2,-106.67131,-102.92769)"
-               style="fill:#bebebe;fill-opacity:1">
-              <path
-                 inkscape:connector-curvature="0"
-                 id="path17559"
-                 d="m 293.97129,382.12115 0,3.74999 2.50001,0 0,-3.74999 -2.50001,0 z m 0,8.74998 0,3.75 2.50001,0 0,-3.75 -2.50001,0 z"
-                 style="display:inline;opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-            </g>
-          </g>
-          <rect
-             y="354.03162"
-             x="233.59288"
-             height="34.285683"
-             width="35.756481"
-             id="rect9822"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(1.000013,0,0,1.0000209,-34.695728,-0.00719494)"
-           style="display:inline"
-           id="g9888"
-           inkscape:label="tool-move">
-          <rect
-             ry="0.428545"
-             y="313.57486"
-             x="236.2766"
-             height="31.030304"
-             width="31.030304"
-             id="rect5007"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.969697;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
-             style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.10701809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="rect5009"
-             width="11.082252"
-             height="11.082252"
-             x="245.1424"
-             y="324.6571"
-             ry="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path13177"
-             d="m 245.1424,320.22421 5.54113,-6.64935 5.54112,6.64935 -11.08225,0"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.21645021px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.21645021px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 245.1424,340.17226 5.54113,6.64935 5.54112,-6.64935 -11.08225,0"
-             id="path13179"
-             inkscape:connector-curvature="0" />
-          <path
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.21645021px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 260.65755,324.65711 6.64935,5.54113 -6.64935,5.54112 0,-11.08225"
-             id="path13181"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path13183"
-             d="m 240.7095,324.65711 -6.64935,5.54113 6.64935,5.54112 0,-11.08225"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.21645021px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <rect
-             y="311.3584"
-             x="234.06015"
-             height="35.463207"
-             width="35.463203"
-             id="rect9886"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(2.216479,0,0,2.2164966,332.35621,-1985.7355)"
-           id="g9935"
-           inkscape:label="reference-local">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4816"
-             d="m 0,1038.8622 15,0"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 0,1044.8622 15,0"
-             id="path4818"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4820"
-             d="m 0,1050.8622 15,0"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 1.5,1037.3622 0,15"
-             id="path4822"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4824"
-             d="m 7.5,1037.3622 0,15"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 13.5,1037.3622 0,15"
-             id="path4826"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4847"
-             d="m 5,1042.3622 0,5 5,0 0,-5 z"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <rect
-             y="1036.3622"
-             x="0"
-             height="16"
-             width="16"
-             id="rect9933"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(2.216479,0,0,2.2164966,376.68579,-1985.7358)"
-           id="g9986"
-           inkscape:label="reference-world">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4816-4"
-             d="m 0,1038.8622 15,0"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 0,1044.8622 15,0"
-             id="path4818-8"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4820-9"
-             d="m 0,1050.8622 15,0"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1.00000024px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 1.5000003,1037.3623 0,15"
-             id="path4822-2"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4824-5"
-             d="m 7.5,1037.3622 0,15"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 13.5,1037.3622 0,15"
-             id="path4826-9"
-             inkscape:connector-curvature="0" />
-          <rect
-             y="1036.3622"
-             x="0"
-             height="16"
-             width="16"
-             id="rect9984"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(2.216479,0,0,2.2164966,421.01537,-1985.7355)"
-           id="g10033"
-           inkscape:label="axis-local">
-          <path
-             inkscape:connector-curvature="0"
-             id="path6081"
-             d="m 1,1046.3622 2.4e-5,5 4.999976,0 -2.4e-5,-5 -4.999976,0 z"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path6458"
-             d="m 1.4999999,1037.3622 0,13.5 13.4999991,0"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
-             y="1036.3622"
-             x="0"
-             height="16"
-             width="16"
-             id="rect10031"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(2.216479,0,0,2.2164966,465.34494,-1985.7355)"
-           id="g10075"
-           inkscape:label="axis-world">
-          <path
-             inkscape:connector-curvature="0"
-             id="path6081-7"
-             d="m 6,1041.3622 2.4e-5,5 4.999976,0 -2.4e-5,-5 -4.999976,0 z"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path6458-7"
-             d="m 1.5,1037.3622 0,13.5 13.5,0"
-             style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
-             y="1036.3622"
-             x="0"
-             height="16"
-             width="16"
-             id="rect10062"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(1.000013,0,0,1.0000209,50.116236,-0.00719736)"
-           style="display:inline"
-           id="g10109"
-           inkscape:label="tool-rotate">
-          <rect
-             transform="matrix(0.9983547,0,0,0.99816217,38.799839,0.62684985)"
-             ry="0.428545"
-             y="313.57486"
-             x="157.25436"
-             height="31.030304"
-             width="31.030304"
-             id="rect3436-2"
-             style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.969697;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
-             style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.969697;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="rect4429"
-             width="31.030304"
-             height="31.030304"
-             x="195.79474"
-             y="313.57486"
-             ry="0.428545"
-             transform="translate(-3.8809242e-7,-6.6363551e-6)" />
-          <rect
-             ry="0"
-             y="324.6571"
-             x="204.66054"
-             height="11.082252"
-             width="11.082252"
-             id="rect4400-1"
-             style="display:inline;opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.10701809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             transform="translate(-3.8809242e-7,-6.6363551e-6)" />
-          <g
-             transform="matrix(0.70275051,0.71143642,-0.71143634,0.70275051,297.39677,-51.392458)"
-             id="g4658">
-            <path
-               inkscape:connector-curvature="0"
-               id="path4581"
-               transform="matrix(2.2164502,0,0,2.2164504,193.57829,311.35841)"
-               d="M 7.5039062,-1 7.5,4 10.896484,1.5 7.5039062,-1 Z M 7.5,1 A 7.4999999,7.5000009 0 0 0 0,8.5 l 1,0 A 6.4999958,6.4999962 0 0 1 7.5,2 l 0,-1 z"
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-            <path
-               inkscape:transform-center-y="4.7500012"
-               inkscape:transform-center-x="-2.050934"
-               inkscape:connector-curvature="0"
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               d="m 210.18868,351.25452 0.009,-11.08226 -7.52814,5.54113 7.51948,5.54113 z m 0.009,-4.4329 a 16.623376,16.62338 0 0 0 16.62337,-16.62338 l -2.21645,0 a 14.406917,14.406919 0 0 1 -14.40692,14.40693 l 0,2.21645 z"
-               id="path4643" />
-          </g>
-          <rect
-             y="311.3584"
-             x="193.57829"
-             height="35.463207"
-             width="35.463203"
-             id="rect10104"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(1.0389745,0,0,1.0389828,1.7673213,-11.217181)"
-           style="display:inline"
-           id="g10162"
-           inkscape:label="tool-scale">
-          <rect
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.969697;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="rect5025"
-             width="32"
-             height="32"
-             x="275.52103"
-             y="312.60516"
-             ry="0.44193703" />
-          <rect
-             inkscape:transform-center-x="-2.7723849"
-             ry="0"
-             y="333.93848"
-             x="275.52103"
-             height="10.666667"
-             width="10.666667"
-             id="rect5036"
-             style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1103624;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <rect
-             ry="0.43526387"
-             y="313.67181"
-             x="276.58768"
-             height="29.866667"
-             width="29.866667"
-             id="rect5038"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:#bebebe;stroke-width:2.13333344;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4.26666666, 4.26666666;stroke-dashoffset:1.91999948;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path8349"
-             d="m 288.84901,331.27719 11.02393,-11.02434"
-             style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bebebe;stroke-width:1.49333334;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend)" />
-          <rect
-             y="310.47183"
-             x="275.52103"
-             height="34.133331"
-             width="34.133331"
-             id="rect10160"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(2.216479,0,0,2.2164966,598.33368,-1985.7355)"
-           id="g10207"
-           inkscape:label="stop">
-          <path
-             inkscape:connector-curvature="0"
-             id="path5439"
-             d="m 1.0000022,1037.3622 0,14 13.9999998,0 0,-14 z"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <rect
-             y="1036.3622"
-             x="0"
-             height="16"
-             width="16"
-             id="rect10205"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           transform="matrix(2.216479,0,0,2.2164966,554.0041,-1985.7355)"
-           id="g10234"
-           inkscape:label="run">
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path5418"
-             d="m 1,1037.3622 0,14 14,-7 z"
-             style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          <rect
-             y="1036.3622"
-             x="0"
-             height="16"
-             width="16"
-             id="rect10232"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           id="g4435"
-           inkscape:export-xdpi="90"
-           inkscape:export-ydpi="90">
-          <rect
-             y="311.3577"
-             x="686.99286"
-             height="35.463947"
-             width="35.463665"
-             id="rect4378"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.22164875;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-          <g
-             transform="translate(13.298899,5.5412161)"
-             id="g4380">
-            <rect
-               y="308.03299"
-               x="682.55988"
-               height="6.6494899"
-               width="6.649437"
-               id="rect4348"
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-            <rect
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               id="rect4350"
-               width="6.649437"
-               height="6.6494899"
-               x="693.64227"
-               y="319.11548" />
-            <rect
-               y="330.19797"
-               x="693.64227"
-               height="6.6494899"
-               width="6.649437"
-               id="rect4352"
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path4364"
-               d="m 693.64227,322.44019 -6.64943,0"
-               style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:2.21648788px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path4356"
-               d="m 685.8846,314.68248 0,17.73197"
-               style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:2.21648788px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path4358"
-               d="m 693.64227,333.52267 -8.86592,0"
-               style="fill:none;fill-rule:evenodd;stroke:#bebebe;stroke-width:2.21648788px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          </g>
-        </g>
-        <g
-           id="g4445"
-           style="opacity:0.99"
-           inkscape:export-xdpi="90"
-           inkscape:export-ydpi="90">
-          <rect
-             y="311.3577"
-             x="642.66327"
-             height="35.463947"
-             width="35.463665"
-             id="rect4397"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-          <g
-             transform="translate(-7.6375662e-7,2.2164735)"
-             id="g4430"
-             style="">
-            <path
-               inkscape:connector-curvature="0"
-               id="rect4390"
-               d="m 648.75859,324.65669 -3.87884,2.21649 15.51535,8.86599 15.51535,-8.86599 -3.87883,-2.21649 -11.63652,6.64949 -11.63651,-6.64949 z"
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.25820315;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-            <rect
-               transform="matrix(0.86824146,0.49614188,-0.86824146,0.49614188,0,0)"
-               y="-66.527168"
-               x="694.08502"
-               height="17.869787"
-               width="17.869934"
-               id="rect4353-7"
-               style="display:inline;opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.25820315;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-            <path
-               inkscape:connector-curvature="0"
-               style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.25820315;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               d="m 648.75859,331.30618 -3.87884,2.21649 15.51535,8.86599 15.51535,-8.86599 -3.87883,-2.21649 -11.63652,6.64949 -11.63651,-6.64949 z"
-               id="path4419" />
-          </g>
-        </g>
-        <g
-           inkscape:export-filename="/home/dani/git/crown/tools/ui/icons/theme/layer-visible.png"
-           inkscape:export-xdpi="90"
-           inkscape:export-ydpi="90"
-           id="g4740"
-           transform="translate(0,1.4759957)">
-          <g
-             id="g4736">
-            <path
-               style="opacity:0.98999999;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               d="m 749.05424,317.27005 a 15.51533,10.34367 0 0 0 -15.51535,10.34365 15.51533,10.34367 0 0 0 15.51535,10.34365 15.51533,10.34367 0 0 0 15.51536,-10.34365 15.51533,10.34367 0 0 0 -15.51536,-10.34365 z m 0,1.72731 a 14.22239,8.6197258 0 0 1 14.22241,8.61634 14.22239,8.6197258 0 0 1 -14.22241,8.62139 14.22239,8.6197258 0 0 1 -14.2224,-8.62139 14.22239,8.6197258 0 0 1 14.2224,-8.61634 z"
-               id="path4620"
-               inkscape:connector-curvature="0" />
-            <path
-               style="opacity:0.98999999;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               d="m 749.05427,320.50244 a 7.1112019,7.1112598 0 0 0 -7.11123,7.11123 7.1112019,7.1112598 0 0 0 7.11123,7.11129 7.1112019,7.1112598 0 0 0 7.11119,-7.11129 7.1112019,7.1112598 0 0 0 -7.11119,-7.11123 z m 0,3.55564 a 3.5556017,3.5556304 0 0 1 3.5556,3.55559 3.5556017,3.5556304 0 0 1 -3.5556,3.55564 3.5556017,3.5556304 0 0 1 -3.55562,-3.55564 3.5556017,3.5556304 0 0 1 3.55562,-3.55559 z"
-               id="path4625"
-               inkscape:connector-curvature="0" />
-          </g>
-          <rect
-             y="309.88171"
-             x="731.32239"
-             height="35.463947"
-             width="35.463665"
-             id="rect4677"
-             style="opacity:0.98999999;fill:none;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-        </g>
-        <g
-           inkscape:export-filename="/home/dani/git/crown/tools/ui/icons/theme/layer-locked.png"
-           inkscape:export-xdpi="90"
-           inkscape:export-ydpi="90"
-           id="g4813"
-           transform="translate(2.2164578,1.3064865e-5)">
-          <rect
-             y="311.3577"
-             x="773.43555"
-             height="35.463947"
-             width="35.463665"
-             id="rect4781"
-             style="opacity:0.98999999;fill:none;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1" />
-          <g
-             transform="translate(-2.2164556,2.7705585)"
-             id="g4809">
-            <path
-               style="opacity:0.98999999;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linejoin:miter;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-dashoffset:0.89999974;stroke-opacity:1"
-               d="m 784.51792,326.31911 0,13.29898 17.73183,0 0,-13.29898 z m 8.86592,2.21649 c 1.39901,-10e-6 2.53313,1.15775 2.53313,2.58591 -7.2e-4,0.92312 -0.48343,1.77585 -1.26656,2.23741 l 0,4.04268 -2.53315,0 0,-4.04772 c -0.7816,-0.46066 -1.26407,-1.31105 -1.26654,-2.23237 0,-1.42816 1.13412,-2.58591 2.53312,-2.58591 z"
-               id="rect4755"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="cccccsccccccs" />
-            <path
-               sodipodi:nodetypes="cssc"
-               inkscape:connector-curvature="0"
-               id="path4773"
-               d="m 787.84264,326.31911 0,-8.86598 c 0,-3.47123 11.08239,-3.47123 11.08239,0 l 0,8.86598"
-               style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bebebe;stroke-width:2.21648812px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-          </g>
-        </g>
-      </g>
-    </g>
-  </g>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<marker id="a" orient="auto" overflow="visible" refX="0" refY="0">
+		<path d="m8.71859 4.03374-10.92588-4.01773 10.92588-4.01772c-1.7455 2.37206-1.73544 5.61745 0 8.03544z" fill="#bebebe" fill-rule="evenodd" stroke="#bebebe" stroke-linejoin="round" stroke-width=".625" transform="scale(-.6)"/>
+	</marker>
+	<g transform="matrix(.45117 0 0 .45116 -69.948 -140.472)">
+		<rect fill="none" height="31.03" ry=".429" width="31.03" x="157.254" y="313.575"/>
+		<path d="m166.12 335.739h11.082v11.082h-11.082z" fill="#bebebe"/>
+		<path d="m171.66148 313.5742v15.51548" fill="none" stroke="#bebebe" stroke-width="2.216"/>
+		<path d="m166.12028 324.65669 5.5412 6.64949 5.5412-6.64949z" fill="#bebebe" fill-rule="evenodd"/>
+		<path d="m155.038 311.358h35.464v35.464h-35.464z" fill="none"/>
+		<g transform="matrix(.99181 0 0 1.03437 277.995 -54.841)">
+			<rect fill="none" height="44.8" opacity=".98" rx=".178" transform="matrix(.69837 0 0 .66964 73.229 122.991)" width="44.8" x="231.571" y="349.721"/>
+			<g fill="#bebebe">
+				<rect height="2.5" opacity=".98" rx=".071" transform="matrix(.89391 0 0 .85714 24.444 52.213)" width="20" x="251.471" y="374.621"/>
+				<rect height="2.5" opacity=".98" rx=".071" transform="matrix(.89391 0 0 .85714 24.444 52.213)" width="20" x="251.471" y="382.121"/>
+				<rect height="2.5" opacity=".98" rx=".071" transform="matrix(0 .85714 -.89391 0 24.444 52.213)" width="20" x="369.621" y="-258.971"/>
+				<rect height="2.5" opacity=".98" rx=".071" transform="matrix(0 .85714 -.89391 0 24.444 52.213)" width="20" x="369.621" y="-266.471"/>
+			</g>
+			<g transform="matrix(.68749 .65921 -.73744 .70711 343.588 -54.025)">
+				<path d="m240.50438 355.61768c-4.14215 0-7.50003 3.35786-7.50003 7.49999s3.35788 7.49999 7.50003 7.49999h4.57215v-4.5h-4.57215c-1.65686 0-3.00001-1.34314-3.00001-2.99999s1.34315-3 3.00001-3h4.57215v-4.49999z" fill="#d40000"/>
+				<path d="m246.09455 355.61738v4.49999h3.00001v-4.49999zm0 10.49998v4.5h3.00001v-4.5z" fill="#bebebe"/>
+			</g>
+			<path d="m233.593 354.032h35.756v34.286h-35.756z" fill="none"/>
+		</g>
+		<g transform="matrix(1.00001 0 0 1.00002 -34.696 -.007)">
+			<rect fill="none" height="31.03" ry=".429" width="31.03" x="236.277" y="313.575"/>
+			<g fill="#bebebe">
+				<path d="m245.142 324.657h11.082v11.082h-11.082z"/>
+				<g fill-rule="evenodd">
+					<path d="m245.1424 320.22421 5.54113-6.64935 5.54112 6.64935z"/>
+					<path d="m245.1424 340.17226 5.54113 6.64935 5.54112-6.64935z"/>
+					<path d="m260.65755 324.65711 6.64935 5.54113-6.64935 5.54112z"/>
+					<path d="m240.7095 324.65711-6.64935 5.54113 6.64935 5.54112z"/>
+				</g>
+			</g>
+			<path d="m234.06 311.358h35.463v35.463h-35.463z" fill="none"/>
+		</g>
+		<g transform="matrix(2.21648 0 0 2.2165 332.356 -1985.736)">
+			<g fill="none" stroke="#bebebe">
+				<path d="m0 1038.8622h15"/>
+				<path d="m0 1044.8622h15"/>
+				<path d="m0 1050.8622h15"/>
+				<path d="m1.5 1037.3622v15"/>
+				<path d="m7.5 1037.3622v15"/>
+				<path d="m13.5 1037.3622v15"/>
+			</g>
+			<path d="m5 1042.3622v5h5v-5z" fill="#bebebe" fill-rule="evenodd"/>
+			<path d="m0 1036.362h16v16h-16z" fill="none"/>
+		</g>
+		<g fill="none" transform="matrix(2.21648 0 0 2.2165 376.686 -1985.736)">
+			<g stroke="#bebebe">
+				<path d="m0 1038.8622h15"/>
+				<path d="m0 1044.8622h15"/>
+				<path d="m0 1050.8622h15"/>
+				<path d="m1.5 1037.3623v15"/>
+				<path d="m7.5 1037.3622v15"/>
+				<path d="m13.5 1037.3622v15"/>
+			</g>
+			<path d="m0 1036.362h16v16h-16z"/>
+		</g>
+		<g transform="matrix(2.21648 0 0 2.2165 421.015 -1985.736)">
+			<path d="m1 1046.3622.00002 5h4.99998l-.00002-5z" fill="#bebebe" fill-rule="evenodd"/>
+			<path d="m1.5 1037.3622v13.5h13.5" fill="none" stroke="#bebebe"/>
+			<path d="m0 1036.362h16v16h-16z" fill="none"/>
+		</g>
+		<g transform="matrix(2.21648 0 0 2.2165 465.345 -1985.736)">
+			<path d="m6 1041.3622.00002 5h4.99998l-.00002-5z" fill="#bebebe" fill-rule="evenodd"/>
+			<path d="m1.5 1037.3622v13.5h13.5" fill="none" stroke="#bebebe"/>
+			<path d="m0 1036.362h16v16h-16z" fill="none"/>
+		</g>
+		<g transform="matrix(1.00001 0 0 1.00002 50.116 -.007)">
+			<rect fill="none" height="31.03" ry=".429" transform="matrix(.99835 0 0 .99816 38.8 .627)" width="31.03" x="157.254" y="313.575"/>
+			<rect fill="none" height="31.03" ry=".429" width="31.03" x="195.795" y="313.575"/>
+			<path d="m204.661 324.657h11.082v11.082h-11.082z" fill="#bebebe"/>
+			<g transform="matrix(.70275 .71144 -.71144 .70275 297.397 -51.392)">
+				<path d="m210.21004 309.14155-.00867 11.08225 7.52813-5.54112zm-.00867 4.4329a16.62338 16.62338 0 0 0 -16.62338 16.62338h2.21645a14.40693 14.40693 0 0 1 14.40693-14.40693z" fill="#bebebe"/>
+				<path d="m210.18868 351.25452.009-11.08226-7.52814 5.54113 7.51948 5.54113zm.009-4.4329a16.62338 16.62338 0 0 0 16.62337-16.62338h-2.21645a14.40692 14.40692 0 0 1 -14.40692 14.40693z" fill="#bebebe"/>
+			</g>
+			<path d="m193.578 311.358h35.463v35.463h-35.463z" fill="none"/>
+		</g>
+		<g transform="matrix(1.03897 0 0 1.03898 1.767 -11.217)">
+			<rect fill="none" height="32" ry=".442" width="32" x="275.521" y="312.605"/>
+			<path d="m275.521 333.938h10.667v10.667h-10.667z" fill="#bebebe"/>
+			<g fill="none">
+				<rect height="29.867" ry=".435" stroke="#bebebe" stroke-dasharray="4.267 4.267" stroke-dashoffset="1.92" stroke-width="2.133" width="29.867" x="276.588" y="313.672"/>
+				<path d="m288.84901 331.27719 11.02393-11.02434" marker-end="url(#a)" stroke="#bebebe" stroke-width="1.493"/>
+				<path d="m275.521 310.472h34.133v34.133h-34.133z"/>
+			</g>
+		</g>
+		<g transform="matrix(2.21648 0 0 2.2165 598.334 -1985.736)">
+			<path d="m1 1037.3622v14h14v-14z" fill="#bebebe" fill-rule="evenodd"/>
+			<path d="m0 1036.362h16v16h-16z" fill="none"/>
+		</g>
+		<g transform="matrix(2.21648 0 0 2.2165 554.004 -1985.736)">
+			<path d="m1 1037.3622v14l14-7z" fill="#bebebe" fill-rule="evenodd"/>
+			<path d="m0 1036.362h16v16h-16z" fill="none"/>
+		</g>
+		<path d="m686.993 311.358h35.464v35.464h-35.464z" fill="none"/>
+		<g fill="#bebebe">
+			<path d="m695.859 313.574h6.649v6.649h-6.649z"/>
+			<path d="m706.941 324.656h6.649v6.649h-6.649z"/>
+			<path d="m706.941 335.739h6.649v6.649h-6.649z"/>
+		</g>
+		<g fill="none" stroke="#bebebe" stroke-width="2.216">
+			<path d="m706.94127 327.98119h-6.64943"/>
+			<path d="m699.1836 320.22348v17.73197"/>
+			<path d="m706.94127 339.06367h-8.86592"/>
+		</g>
+		<g opacity=".99">
+			<path d="m642.663 311.358h35.464v35.464h-35.464z" fill="none" opacity="1"/>
+			<g fill="#bebebe" transform="translate(0 2.216)">
+				<path d="m648.75859 324.65669-3.87884 2.21649 15.51535 8.86599 15.51535-8.86599-3.87883-2.21649-11.63652 6.64949z" opacity="1"/>
+				<path d="m694.085-66.527h17.87v17.87h-17.87z" opacity="1" transform="matrix(.86824 .49614 -.86824 .49614 0 0)"/>
+				<path d="m648.75859 331.30618-3.87884 2.21649 15.51535 8.86599 15.51535-8.86599-3.87883-2.21649-11.63652 6.64949z" opacity="1"/>
+			</g>
+		</g>
+		<path d="m749.05424 318.74605a15.51533 10.34367 0 0 0 -15.51535 10.34365 15.51533 10.34367 0 0 0 15.51535 10.34365 15.51533 10.34367 0 0 0 15.51536-10.34365 15.51533 10.34367 0 0 0 -15.51536-10.34365zm0 1.72731a14.22239 8.61973 0 0 1 14.22241 8.61634 14.22239 8.61973 0 0 1 -14.22241 8.62139 14.22239 8.61973 0 0 1 -14.2224-8.62139 14.22239 8.61973 0 0 1 14.2224-8.61634z" fill="#bebebe" opacity=".99"/>
+		<path d="m749.05427 321.97844a7.1112 7.11126 0 0 0 -7.11123 7.11123 7.1112 7.11126 0 0 0 7.11123 7.11129 7.1112 7.11126 0 0 0 7.11119-7.11129 7.1112 7.11126 0 0 0 -7.11119-7.11123zm0 3.55564a3.5556 3.55563 0 0 1 3.5556 3.55559 3.5556 3.55563 0 0 1 -3.5556 3.55564 3.5556 3.55563 0 0 1 -3.55562-3.55564 3.5556 3.55563 0 0 1 3.55562-3.55559z" fill="#bebebe" opacity=".99"/>
+		<path d="m731.322 311.358h35.464v35.464h-35.464z" fill="none" opacity=".99"/>
+		<path d="m775.652 311.358h35.464v35.464h-35.464z" fill="none" opacity=".99"/>
+		<path d="m784.51792 329.09011v13.29898h17.73183v-13.29898zm8.86592 2.21649c1.39901-.00001 2.53313 1.15775 2.53313 2.58591-.00072.92312-.48343 1.77585-1.26656 2.23741v4.04268h-2.53315v-4.04772c-.7816-.46066-1.26407-1.31105-1.26654-2.23237 0-1.42816 1.13412-2.58591 2.53312-2.58591z" fill="#bebebe" opacity=".99"/>
+		<path d="m787.84264 329.09011v-8.86598c0-3.47123 11.08239-3.47123 11.08239 0v8.86598" fill="none" stroke="#bebebe" stroke-width="2.216"/>
+	</g>
 </svg>


### PR DESCRIPTION
Losslessly reduced SVG images size.

Also, PNG images can be reduced up to 30-40% using tools like oxipng/optipng. If you care about resources size.