### PR TITLE
Fix level editor key uint->int compile error

### DIFF
--- a/tools/level_editor/engine_view.vala
+++ b/tools/level_editor/engine_view.vala
@@ -40,7 +40,7 @@ namespace Crown
 
 		private string key_to_string(int k)
 		{
-			switch (k)
+			switch ((uint)k)
 			{
 			case Gdk.Key.w: return "w";
 			case Gdk.Key.a: return "a";
@@ -71,10 +71,10 @@ namespace Crown
 			_window_id = 0;
 
 			_keys = new HashMap<int, bool>();
-			_keys[Gdk.Key.w] = false;
-			_keys[Gdk.Key.a] = false;
-			_keys[Gdk.Key.s] = false;
-			_keys[Gdk.Key.d] = false;
+			_keys[(int)Gdk.Key.w] = false;
+			_keys[(int)Gdk.Key.a] = false;
+			_keys[(int)Gdk.Key.s] = false;
+			_keys[(int)Gdk.Key.d] = false;
 
 			// Widgets
 			_socket = new Gtk.Socket();


### PR DESCRIPTION
I followed the build instruction in README for Linux and compilation failed with:
`error: Cannot convert from 'uint' to 'int'`
I fixed the compilation error and tested 01-physics sample with fps camera and it works.

Tested on Arch Linux.