### PR TITLE
tools: widgets: input_double.vala: fix gray fields

### DIFF
--- a/tools/level_editor/resources/ui/style.css
+++ b/tools/level_editor/resources/ui/style.css
@@ -29,24 +29,52 @@ notebook > header tab {
 	min-height: 22px;
 }
 
-.axis > entry {
+.axis entry {
 	min-width: 22px;
 }
 
-.axis.x > entry {
+.axis.x entry {
 	background: rgba(180, 0, 0, 0.2);
 }
 
-.axis.y > entry {
+.axis.y entry {
 	background: rgba(0, 180, 0, 0.2);
 }
 
-.axis.z > entry {
+.axis.z entry {
 	background: rgba(0, 0, 180, 0.2);
 }
 
-.axis.w > entry {
+.axis.w entry {
 	background: rgba(180, 180, 180, 0.2);
+}
+
+.axis.x .label-button {
+	background-image: none;
+	background-color: rgba(180, 0, 0, 0.2);
+	border-color: transparent;
+}
+
+.axis.y .label-button {
+	background-image: none;
+	background-color: rgba(0, 180, 0, 0.2);
+	border-color: transparent;
+}
+
+.axis.z .label-button {
+	background-image: none;
+	background-color: rgba(0, 0, 180, 0.2);
+	border-color: transparent;
+}
+
+.axis.w .label-button {
+	background-image: none;
+	background-color: rgba(180, 180, 180, 0.2);
+	border-color: transparent;
+}
+
+.input-double-preview {
+	color: transparent;
 }
 
 .counter-label {

--- a/tools/widgets/input_double.vala
+++ b/tools/widgets/input_double.vala
@@ -76,6 +76,7 @@ public class InputDouble : InputField
 		_entry.input_purpose = Gtk.InputPurpose.FREE_FORM;
 		_entry.set_width_chars(1);
 		_entry.editable = false;
+		_entry.get_style_context().add_class("input-double-preview");
 
 		_entry.activate.connect(on_activate);
 		_entry.focus_in_event.connect(on_focus_in);
@@ -88,6 +89,7 @@ public class InputDouble : InputField
 		_event_box = new Gtk.EventBox();
 		_event_box.add(_label);
 		_event_box.can_focus = false;
+		_event_box.set_visible_window(false);
 
 		_overlay = new Gtk.Overlay();
 		_overlay.add(_entry);
@@ -216,6 +218,7 @@ public class InputDouble : InputField
 			_event_box.visible = false;
 
 		_entry.editable = true;
+		_entry.get_style_context().remove_class("input-double-preview");
 
 		if (_inconsistent)
 			_entry.text = "";
@@ -248,6 +251,7 @@ public class InputDouble : InputField
 
 		_entry.select_region(0, 0);
 		_entry.editable = false;
+		_entry.get_style_context().add_class("input-double-preview");
 		_label.set_text(_entry.text);
 		_event_box.visible = true;
 
@@ -265,6 +269,7 @@ public class InputDouble : InputField
 	{
 		_event_box.visible = false;
 		_entry.editable = true;
+		_entry.get_style_context().remove_class("input-double-preview");
 		_entry.grab_focus();
 
 		if (_inconsistent)


### PR DESCRIPTION
Fix InputDouble widgets, now they are red green and blue again.